### PR TITLE
Add Sign Up/Login Modal

### DIFF
--- a/rms/src/components/MenuComponent.js
+++ b/rms/src/components/MenuComponent.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import styled from 'styled-components';
 import ReactBootstrap, {Jumbotron, Button, Col, Grid, Panel, Navbar,Container,FormGroup, Nav, Form, FormControl ,NavDropdown} from 'react-bootstrap'
-import LoginModal from './loginModal.js';
+import UserAuthModal from './UserAuthModal.js';
 //
 // const Styles = styled.div`
 //   .navbar { background-color: #222; }
@@ -25,7 +25,8 @@ class NavigationBar extends Component{
     constructor(props) {
         super(props);
         this.state = {
-            showModal: false
+            showModal: false,
+            isTokenDetected: false
         }
         this.handleModal = this.handleModal.bind(this);
     }
@@ -70,13 +71,18 @@ class NavigationBar extends Component{
                             <Button variant="outline-success">Search</Button>
                         </Form>
                         <Nav>
-                            <Button variant="dark" onClick={() => this.handleModal(true)}>Login</Button>
+                            <Button variant="dark" onClick={() => this.handleModal(true)}>
+                                { 
+                                    this.state.isTokenDetected ? 'Login' : 'Sign Up'
+                                }
+                            </Button>
                         </Nav>
                     </Navbar.Collapse>
                 </Container>
-                <LoginModal
+                <UserAuthModal
                     handleModal={this.handleModal}
                     showModal={this.state.showModal}
+                    isTokenDetected={this.state.isTokenDetected}
                 />
             </Navbar>
         )

--- a/rms/src/components/UserAuthModal.js
+++ b/rms/src/components/UserAuthModal.js
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Modal, Form, Button } from 'react-bootstrap';
 
-const LoginModal = (props) => {
+const UserAuthModal = (props) => {
+  const [modalTitle, setModalTitle] = useState(false);
+
+  useEffect(() => {
+    setModalTitle(props.isTokenDetected);
+  }, [props.isTokenDetected])
+
   return (
     <>
       <Modal
@@ -11,7 +17,11 @@ const LoginModal = (props) => {
         centered
       >
         <Modal.Header closeButton>
-          <Modal.Title>User Login</Modal.Title>
+          <Modal.Title>
+            {
+              modalTitle ? 'User Login' : 'User Sign Up'
+            }
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Form>
@@ -31,4 +41,4 @@ const LoginModal = (props) => {
   )
 }
 
-export default LoginModal;
+export default UserAuthModal;


### PR DESCRIPTION
Update Login Modal to UserAuthModal - Display Login or Sign up depending if session exists in client browser

Assuming a session cookie or JWT token is saved on the client browser, we can check if the user on the site has it. If it does, change the Modal to Login and if not, show them the Sign Up.